### PR TITLE
fix: Set fixed aspect ratio for homepage carousel

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -23,13 +23,19 @@
 }
 
 /* Header Carousel Styles */
-.masthead .carousel,
+.masthead .carousel {
+    width: 100%;
+    aspect-ratio: 1200 / 673;
+    background: #2c3e50; /* Fallback color in case of image loading issues */
+}
+
 .masthead .carousel-inner,
 .masthead .carousel-item {
     height: 100%;
 }
 
 .masthead .carousel-item img {
+    width: 100%;
     height: 100%;
     object-fit: cover;
     object-position: center;


### PR DESCRIPTION
This commit adjusts the carousel styling to match the user's requirements.

- Modifies `css/custom.css` to enforce a fixed aspect ratio of 1200:673 on the homepage carousel.
- Uses the `aspect-ratio` CSS property for a modern and clean implementation.
- Ensures the image continues to fill the frame using `object-fit: cover`.