### PR TITLE
fix: Apply aspect ratio to individual carousel items

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -23,15 +23,9 @@
 }
 
 /* Header Carousel Styles */
-.masthead .carousel {
-    width: 100%;
+.masthead .carousel-item {
     aspect-ratio: 1200 / 673;
     background: #2c3e50; /* Fallback color in case of image loading issues */
-}
-
-.masthead .carousel-inner,
-.masthead .carousel-item {
-    height: 100%;
 }
 
 .masthead .carousel-item img {


### PR DESCRIPTION
This commit refactors the carousel CSS to apply the 1200:673 aspect ratio directly to each `.carousel-item`, rather than the parent container. This addresses the user's feedback to ensure the ratio is enforced on every slide in the carousel inner.