### PR TITLE
fix: Implement stable aspect ratio for carousel

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -23,9 +23,24 @@
 }
 
 /* Header Carousel Styles */
+.masthead .carousel {
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: 56.0833%; /* Aspect Ratio 673 / 1200 */
+    background: #2c3e50;
+}
+
+.masthead .carousel-inner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
 .masthead .carousel-item {
-    aspect-ratio: 1200 / 673;
-    background: #2c3e50; /* Fallback color in case of image loading issues */
+    height: 100%; /* Make item fill the carousel-inner */
 }
 
 .masthead .carousel-item img {


### PR DESCRIPTION
This commit implements a more robust CSS solution for the homepage carousel to ensure a stable aspect ratio.

- Refactors the carousel CSS in `css/custom.css`.
- Uses the 'padding-bottom' technique on the main carousel container to create a fixed-size frame that does not change size during slide transitions.
- This resolves the instability issue reported by the user.