### PR TITLE
fix: Remove green background from homepage header

### DIFF
--- a/index.php
+++ b/index.php
@@ -91,7 +91,7 @@ try {
     </nav>
 
     <!-- Masthead-->
-    <header class="masthead bg-primary text-white text-center">
+    <header class="masthead text-white text-center">
         <div id="headerCarousel" class="carousel slide" data-bs-ride="carousel">
             <?php if (!empty($header_photos)): ?>
                 <div class="carousel-indicators">


### PR DESCRIPTION
This commit removes the `bg-primary` class from the `<header>` element in `index.php`. This addresses the user's request to remove the green background color from the header section.